### PR TITLE
feat(workflow): implement PR-per-issue workflow

### DIFF
--- a/templates/.claude/commands/done.md
+++ b/templates/.claude/commands/done.md
@@ -1,5 +1,5 @@
 ---
-description: Mark current issue as complete and suggest next
+description: Mark current issue as complete, create PR, and suggest next
 ---
 
 # Complete Current Issue
@@ -10,21 +10,32 @@ description: Mark current issue as complete and suggest next
    npm run test:run
    ```
 
-2. **Commit changes** (can be messy - will be squashed at end of day):
+2. **Commit changes** with proper format:
    ```bash
    git add -A
-   git commit -m "wip: #<issue> <brief description>"
+   git commit -m "<type>(<scope>): description
+
+   Closes #<issue>
+
+   🤖 Generated with Claude Code
+   Co-Authored-By: Claude <noreply@anthropic.com>"
    ```
 
-3. **Update daily state file**:
-   - Move issue from Active to Completed
-   - Add completion timestamp and notes
+3. **Create Pull Request** for this issue:
+   ```bash
+   git push -u origin issue/<number>-<slug>
+   gh pr create --title "<type>(<scope>): description" --body "Closes #<number>"
+   ```
 
-4. **Update GitHub**: Remove `in-progress` label
+4. **Update daily state file**:
+   - Move issue from Active to Completed
+   - Record PR number and link
+
+5. **Update GitHub**: Remove `in-progress` label
    ```bash
    gh issue edit <number> --remove-label "in-progress"
    ```
 
-5. **Suggest next issue** from today's plan, or offer to run `/ship-day` if plan is complete.
+6. **Suggest next issue** (on fresh branch from main), or offer to run `/ship-day` if plan is complete.
 
 Reference `.claude/skills/daily-workflow/done.md` for full details.

--- a/templates/.claude/commands/next.md
+++ b/templates/.claude/commands/next.md
@@ -1,21 +1,33 @@
 ---
-description: Pick up the next issue from today's plan
+description: Pick up the next issue from today's plan (on fresh branch)
 ---
 
 # Pick Next Issue
 
-1. **Read the current daily state file**: `.claude/daily/$(date +%Y-%m-%d).md`
+1. **Switch to main and pull latest**:
+   ```bash
+   git checkout main
+   git pull origin main
+   ```
 
-2. **Find the next pending issue** in the plan (or use the issue number if specified as argument)
+2. **Read the current daily state file**: `~/.claw/daily/$(date +%Y-%m-%d).md`
 
-3. **Move it to Active status** in the state file with timestamp
+3. **Find the next pending issue** in the plan (or use the issue number if specified)
 
-4. **Update GitHub**: Add `in-progress` label to the issue
+4. **Create issue-specific branch**:
+   ```bash
+   git checkout -b issue/<number>-<short-slug>
+   # Example: issue/42-payment-modal
+   ```
+
+5. **Move it to Active status** in the state file with timestamp and branch name
+
+6. **Update GitHub**: Add `in-progress` label to the issue
    ```bash
    gh issue edit <number> --add-label "in-progress"
    ```
 
-5. **Fetch and present issue context**:
+7. **Fetch and present issue context**:
    ```bash
    gh issue view <number>
    ```
@@ -26,6 +38,6 @@ description: Pick up the next issue from today's plan
    - Relevant perspectives
    - Files likely to be touched
 
-6. **Begin implementation** following TDD (tests first).
+8. **Begin implementation** following TDD (tests first).
 
 Reference `.claude/skills/daily-workflow/next.md` for full details.

--- a/templates/.claude/rules/daily-workflow.md
+++ b/templates/.claude/rules/daily-workflow.md
@@ -2,20 +2,24 @@
 
 This rule file governs the autonomous daily development workflow.
 
-## Branch Naming
-- Daily branches: `daily/YYYY-MM-DD`
+## Branch Naming (PR-per-Issue)
+- Issue branches: `issue/<number>-<short-slug>`
+- Examples: `issue/42-payment-modal`, `issue/53-settings-display`
 - Never push directly to main
-- All work for a day goes on a single branch
+- Each issue gets its own branch and PR
+- Fresh branch from main for each issue
 
-## During-Day Commits
-- Can be messy: "wip", "trying x", "fix"
-- Will be squashed at end of day
-- Each commit should still run tests (but doesn't need perfect messages)
+## Commits (PR-per-Issue)
+- Use conventional format: `<type>(<scope>): <description>`
+- Reference issue: `Closes #123` in commit body
+- Each issue gets clean commits since each has its own PR
+- Tests must pass before committing
 
-## Ship-Time Commits
-- Must follow conventional format: `<type>(<scope>): <description>`
-- Must reference issue numbers: `(#123)` or `Closes #123`
-- Must pass all hooks (test coverage validation)
+## PR Requirements
+- One PR per issue (not batched)
+- PR title matches commit message format
+- PR body includes test plan and links to issue
+- CI must pass before merge
 
 ## Pivot Protocol
 - Always log pivots in the daily file with timestamp

--- a/templates/.claude/skills/daily-workflow/done.md
+++ b/templates/.claude/skills/daily-workflow/done.md
@@ -1,15 +1,18 @@
 # /done
 
-Mark the current issue as complete.
+Mark the current issue as complete and create a PR.
 
 ## What This Skill Does
 
 1. **RUNS /validate FIRST** (mandatory)
 2. Verifies ALL tests pass (unit, integration, E2E)
-3. Commits current changes (can be messy - will be squashed)
-4. Moves issue from "Active" to "Completed" in state file
-5. Updates GitHub label
-6. Suggests next issue
+3. Commits current changes with proper message
+4. **Creates a PR for this issue** (PR-per-issue workflow)
+5. Moves issue from "Active" to "Completed" in state file
+6. Updates GitHub labels
+7. Suggests next issue (on a fresh branch from main)
+
+**Note:** Each issue gets its own PR for easier review and verification.
 
 **Note:** Completed items are tracked in `~/.claw/daily/YYYY-MM-DD.md` for `/summary` to display (spans all tracked repos).
 
@@ -78,10 +81,15 @@ cd apps/license-portal && npx playwright test [feature].spec.ts
 
 ```bash
 git add -A
-git commit -m "wip: #42 payment modal"
+git commit -m "feat(scope): description
+
+Closes #42
+
+🤖 Generated with Claude Code
+Co-Authored-By: Claude <noreply@anthropic.com>"
 ```
 
-Note: Commits during the day can be messy. They'll be squashed by `/ship-day`.
+Note: Use proper conventional commit format since each issue gets its own PR.
 
 ### 3. Update State File
 
@@ -96,26 +104,57 @@ Move issue from "Active" to "Completed":
   - commit: abc1234
 ```
 
-### 4. Update GitHub
+### 4. Create Pull Request
+
+Push branch and create PR for this issue:
+
+```bash
+# Push the issue branch
+git push -u origin issue/42-payment-modal
+
+# Create PR linking to the issue
+gh pr create --title "feat(scope): description" \
+  --body "## Summary
+- Brief description of changes
+
+## Test Plan
+- [ ] Tests pass
+- [ ] Manual verification done
+
+Closes #42
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)"
+```
+
+**PR Guidelines:**
+- Title should match the commit message
+- Body should summarize changes and link to issue
+- Include test plan for verification
+
+### 5. Update GitHub Labels
 
 ```bash
 gh issue edit 42 --remove-label "in-progress"
-# Note: Don't add done-today yet - that happens at ship time
+# PR will auto-close the issue when merged
 ```
 
-### 5. Suggest Next
+### 6. Suggest Next
 
 If there are more issues in today's plan:
 
 ```
 ✓ #42 completed!
+✓ PR #15 created: https://github.com/owner/repo/pull/15
 
 Next in plan: #45 - Invoice download feature
   - Scope: S (30 min - 2 hours)
   - This builds on the modal you just created
 
-Run /next to start, or /pivot if plans changed.
+Run /next to start on a fresh branch, or /pivot if plans changed.
 ```
+
+**Important:** The next issue will start on a fresh branch from main, not the current branch.
+This keeps each PR focused on a single issue.
 
 ## Quick Retrospective
 

--- a/templates/.claude/skills/daily-workflow/next.md
+++ b/templates/.claude/skills/daily-workflow/next.md
@@ -1,14 +1,19 @@
 # /next
 
-Pick up the next issue from today's plan.
+Pick up the next issue from today's plan on a fresh branch.
 
 ## What This Skill Does
 
-1. Reads the current daily state file
-2. Finds the next pending issue in the plan
-3. Moves it to "Active" status
-4. Updates GitHub label to `in-progress`
-5. Provides context for starting work
+1. **Switches to main and pulls latest** (fresh start)
+2. **Creates issue-specific branch** (`issue/<number>-<slug>`)
+3. Reads the current daily state file
+4. Finds the next pending issue in the plan
+5. Moves it to "Active" status
+6. Updates GitHub label to `in-progress`
+7. Provides context for starting work
+
+**Branch Strategy:** Each issue gets its own branch from main.
+This enables PR-per-issue workflow for easier review.
 
 ## Invocation
 
@@ -24,36 +29,58 @@ Or to pick a specific issue:
 
 ## Steps
 
-### 1. Read Current State
+### 1. Switch to Main and Pull Latest
 
 ```bash
-cat .claude/daily/$(date +%Y-%m-%d).md
+git checkout main
+git pull origin main
 ```
 
-### 2. Find Next Issue
+### 2. Read Current State
 
-- If no specific issue requested, pick the first from "Planned"
+```bash
+cat ~/.claw/daily/$(date +%Y-%m-%d).md
+```
+
+### 3. Find Next Issue
+
+- If no specific issue requested, pick the first from "Queued"
 - If issue specified, verify it's in today's plan
 
-### 3. Update State File
+### 4. Create Issue Branch
 
-Move issue from "Planned" to "Active":
+```bash
+# Create branch with issue number and slug
+git checkout -b issue/42-payment-modal
+
+# Branch naming convention:
+# issue/<number>-<short-slug>
+# Examples:
+#   issue/42-payment-modal
+#   issue/53-settings-display
+#   issue/14-version-sync
+```
+
+### 5. Update State File
+
+Move issue from "Queued" to "Active":
 
 ```markdown
 ### Active
 - [ ] #42 - Add payment method update modal
   - status: in_progress
   - started: 10:30
+  - branch: issue/42-payment-modal
   - notes:
 ```
 
-### 4. Update GitHub
+### 6. Update GitHub
 
 ```bash
 gh issue edit 42 --add-label "in-progress"
 ```
 
-### 5. Provide Context
+### 7. Provide Context
 
 Fetch and summarize the issue:
 

--- a/templates/.claude/skills/daily-workflow/plan-day.md
+++ b/templates/.claude/skills/daily-workflow/plan-day.md
@@ -239,14 +239,21 @@ Approve? (y/n/modify)
 ### Step 6: On Approval
 
 ```bash
-# Create daily branch
-git checkout -b daily/$(date +%Y-%m-%d)
+# Start fresh from main
+git checkout main
+git pull origin main
 
-# Mark first issue
+# Create branch for FIRST issue only
+git checkout -b issue/53-settings-display
+
+# Mark first issue as in-progress
 gh issue edit 53 --add-label "in-progress"
 ```
 
-Create state file: `.claude/daily/YYYY-MM-DD.md`
+**Branch Strategy:** Each issue gets its own branch (`issue/<number>-<slug>`).
+When `/done` is called, a PR is created and `/next` starts a fresh branch for the next issue.
+
+Create state file: `~/.claw/daily/YYYY-MM-DD.md`
 
 ---
 
@@ -258,7 +265,7 @@ Create state file: `.claude/daily/YYYY-MM-DD.md`
 ## Config
 hours_available: 4
 maturity: startup
-branch: daily/YYYY-MM-DD
+branch_strategy: pr-per-issue
 started: 09:00
 
 ## Lens Settings
@@ -271,6 +278,7 @@ started: 09:00
 ### Active
 - [ ] #53 - Settings display (~1h)
   - Status: in-progress
+  - Branch: issue/53-settings-display
   - Started: 09:15
 
 ### Queued
@@ -278,7 +286,9 @@ started: 09:00
 - [ ] #56 - Remove quit button (~0.5h)
 
 ### Completed
-(moves here when done)
+- [x] #53 - Settings display
+  - PR: #15 (https://github.com/owner/repo/pull/15)
+  - Completed: 10:30
 
 ### Deferred
 - #58 - API encryption (revisit tomorrow)


### PR DESCRIPTION
## Summary
Implements PR-per-issue workflow where each GitHub issue gets its own branch and PR instead of batching all changes into a single daily branch.

## Changes
- **`/done`**: Now creates a PR after completing each issue
- **`/next`**: Switches to main and creates fresh branch for the next issue
- **`/plan-day`**: Creates issue-specific branch instead of daily branch
- **`daily-workflow.md` rule**: Updated branch naming convention

## Branch Naming Convention
```
issue/<number>-<short-slug>
```
Examples:
- `issue/42-payment-modal`
- `issue/53-settings-display`
- `issue/14-version-sync`

## Benefits
- Easier code review - each PR is focused on one issue
- Independent verification - can test/approve each change independently
- Better git history - clear separation of concerns
- Partial merges - can merge ready PRs while others need work

## Test Plan
- [x] All existing tests pass
- [ ] Try the new workflow on a real issue

Closes #13

🤖 Generated with [Claude Code](https://claude.com/claude-code)